### PR TITLE
fix: correct f-string quotes in logger error message

### DIFF
--- a/endpoints/http_post.py
+++ b/endpoints/http_post.py
@@ -34,7 +34,7 @@ class HTTPPostEndpoint(Endpoint):
         try:
             tool = json.loads(settings.get("app-input-schema"))
         except json.JSONDecodeError:
-            logger.error(f"Invalid app-input-schema: {settings.get("app-input-schema")}")
+            logger.error(f'Invalid app-input-schema: {settings.get("app-input-schema")}')
             raise ValueError("Invalid app-input-schema")
 
         session_id = r.args.get("session_id")

--- a/endpoints/messages.py
+++ b/endpoints/messages.py
@@ -28,7 +28,7 @@ class MessageEndpoint(Endpoint):
         try:
             tool = json.loads(settings.get("app-input-schema"))
         except json.JSONDecodeError:
-            logger.error(f"Invalid app-input-schema: {settings.get("app-input-schema")}")
+            logger.error(f'Invalid app-input-schema: {settings.get("app-input-schema")}')
             raise ValueError("Invalid app-input-schema")
 
         session_id = r.args.get("session_id")


### PR DESCRIPTION
This pull request fixes a syntax error in messages.py and http_post.py caused by incorrect usage of quotes in an f-string expression within a logger statement.

*Problem example*:
```
  File "/Users/zhangxin/Development/labs/langgenius/plugin/dify_plugin_collection/dify-plugin-mcp_server/endpoints/http_post.py", line 37
    logger.error(f"Invalid app-input-schema: {settings.get("app-input-schema")}")
                                                            ^^^
SyntaxError: f-string: unmatched '('
```